### PR TITLE
Run CMK Inventory async: Temporary Fix.

### DIFF
--- a/src/atlantis/supervisor/containers/containers.go
+++ b/src/atlantis/supervisor/containers/containers.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"log"
 	"os/exec"
+	"time"
 )
 
 const (
@@ -196,7 +197,11 @@ func teardown(req *TeardownReq) {
 		usedCPUShares = usedCPUShares - containers[req.id].Manifest.CPUShares
 		delete(containers, req.id)
 		save()
-		inventory()
+		go func() {
+			// inventory() eventually calls back into the supervisor via cmk_admin -I
+			<-time.After(100 * time.Millisecond)
+			inventory()
+		}()
 		req.respChan <- true
 	} else {
 		req.respChan <- false


### PR DESCRIPTION
Since CMK inventory calls back into supervisor, which blocks the
teardown indefinitely, move it to it's own delayed go routine.

This fix has the unfortunate side-effect that if checks hit in the
window when teardown has completed but inventory has not run, cmk
will alert.
