### PR TITLE
Fixed debian skeleton and Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,3 @@
-## Copyright 2014 Ooyala, Inc. All rights reserved.
 ##
 ## This file is licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
 ## except in compliance with the License. You may obtain a copy of the License at
@@ -18,6 +17,14 @@ else
 endif
 ATLANTIS_PATH := $(LIB_PATH)/atlantis
 BUILDER_PATH := $(LIB_PATH)/atlantis-builder
+
+DEB_STAGING := $(PROJECT_ROOT)/staging
+PKG_BIN_DIR := $(DEB_STAGING)/opt/atlantis-supervisor/bin
+
+ifndef VERSION
+	VERSION := "0.1.0"
+endif
+
 GOPATH := $(PROJECT_ROOT):$(VENDOR_PATH):$(ATLANTIS_PATH):$(BUILDER_PATH)
 export GOPATH
 
@@ -26,14 +33,19 @@ all: test
 clean:
 	rm -rf bin pkg $(ATLANTIS_PATH)/src/atlantis/crypto/key.go
 	rm -f example/supervisor example/client example/monitor
+	@rm -rf $(DEB_STAGING) atlantis-supervisor_*.deb
+	rm -rf lib/*
 
 copy-key:
 	@cp $(ATLANTIS_SECRET_DIR)/atlantis_key.go $(ATLANTIS_PATH)/src/atlantis/crypto/key.go
 
-$(ATLANTIS_PATH):
-	@git clone ssh://git@github.com/ooyala/atlantis $(ATLANTIS_PATH)
-	
-$(VENDOR_PATH): | $(ATLANTIS_PATH)
+dependency-components:
+	@git clone https://github.com/ooyala/atlantis $(ATLANTIS_PATH)
+	@git clone https://github.com/ooyala/atlantis-builder $(BUILDER_PATH)
+
+LAST_WORKING_SHA := "8fb2b14845d00ccc21d8847407d151383ba8ea2a"
+
+install-deps: dependency-components
 	@echo "Installing Dependencies..."
 	@rm -rf $(VENDOR_PATH)
 	@mkdir -p $(VENDOR_PATH) || exit 2
@@ -42,7 +54,21 @@ $(VENDOR_PATH): | $(ATLANTIS_PATH)
 	@GOPATH=$(VENDOR_PATH) go get launchpad.net/gocheck
 	@GOPATH=$(VENDOR_PATH) go get github.com/crowdmob/goamz/aws
 	@GOPATH=$(VENDOR_PATH) go get github.com/crowdmob/goamz/s3
+	@GOPATH=$(VENDOR_PATH) go get github.com/fsouza/go-dockerclient
+	@cd $(VENDOR_PATH)/src/github.com/fsouza/go-dockerclient; git reset --hard $(LAST_WORKING_SHA)
 	@echo "Done."
+
+deb: clean install-deps example
+	@cp -a $(PROJECT_ROOT)/deb $(DEB_STAGING)
+	@mkdir -p $(PKG_BIN_DIR)
+
+	@cp example/client $(PKG_BIN_DIR)
+	@cp example/monitor $(PKG_BIN_DIR)
+	@cp example/supervisor $(PKG_BIN_DIR)
+
+	@sed -ri "s/__VERSION__/$(VERSION)/" $(DEB_STAGING)/DEBIAN/control
+	@sed -ri "s/__PACKAGE__/atlantis-supervisor/" $(DEB_STAGING)/DEBIAN/control
+	@dpkg -b $(DEB_STAGING) .
 
 test: clean copy-key | $(VENDOR_PATH)
 ifdef TEST_PACKAGE

--- a/deb/DEBIAN/control
+++ b/deb/DEBIAN/control
@@ -1,0 +1,9 @@
+Package: __PACKAGE__
+Version: __VERSION__
+Section: base
+Priority: Optional
+Architecture: amd64
+Depends: lxc-docker (>= 0.9.0)
+Maintainer: appsplat-team@ooyala.com
+Description: Atlantis Supervisor
+ This is atlantis-supervisor.

--- a/deb/DEBIAN/postrm
+++ b/deb/DEBIAN/postrm
@@ -1,0 +1,4 @@
+#!/bin/bash -e
+
+rm -f /usr/bin/supervisor /usr/bin/monitor /usr/bin/client
+


### PR DESCRIPTION
Pinning `go-dockerclient` to working SHA.
Need to update it as per proper <a href='http://goo.gl/0knMxk' _target='blank'>Go Package Manager.</a>