### PR TITLE
Monitor: Warn on error listing contact groups, rather than error.

### DIFF
--- a/src/atlantis/monitor/monitor.go
+++ b/src/atlantis/monitor/monitor.go
@@ -148,7 +148,7 @@ type ContainerConfig struct {
 func (c *ContainerCheck) verifyContactGroup(group string) bool {
 	output, err := exec.Command("/usr/bin/cmk_admin", "-l").Output()
 	if err != nil {
-		fmt.Printf("%d %s - Error listing existing contact_groups for validation, please try again later! Error: %s\n", Critical, c.Name, err.Error())
+		fmt.Printf("%d %s - Error listing existing contact_groups for validation, please try again later! Error: %s\n", Warning, c.Name, err.Error())
 		return false
 	}
 	for _, l := range strings.Split(string(output), "\n") {


### PR DESCRIPTION
This is based on recent experience, where the check_mk server is
occasionally timing out, but it's only once or twice.  We'll still get
e-mails, and should notice fairly quickly that something's up.